### PR TITLE
Fix: Unify login error handlers

### DIFF
--- a/.github/type-coverage.json
+++ b/.github/type-coverage.json
@@ -2,8 +2,8 @@
   "succeeded": true,
   "atLeast": 90,
   "atLeastFailed": false,
-  "correctCount": 5089,
-  "percent": 93.37,
-  "percentString": "93.37",
-  "totalCount": 5450
+  "correctCount": 5115,
+  "percent": 93.39,
+  "percentString": "93.39",
+  "totalCount": 5477
 }

--- a/src/controllers/auth/login.ts
+++ b/src/controllers/auth/login.ts
@@ -4,7 +4,7 @@ import { TOKEN_TYPE } from "../../constants/database"
 import { HTTP_SUCCESS } from "../../constants/http"
 import { TIMESPAN } from "../../constants/time"
 import { User } from "../../db/schema"
-import { BadRequestError, ForbiddenError, PasswordError } from "../../errors"
+import { BadRequestError, ForbiddenError, LoginError } from "../../errors"
 import generateXsrfToken from "../../middleware/util/xsrfToken"
 import SERVICES from "../../services"
 import { validateHash } from "../../utils/crypt"
@@ -27,13 +27,13 @@ export const login = async (req: Request, res: Response, next: NextFunction) => 
   const getUserByUsernameOrEmail = username ? SERVICES.getUserByUsername : SERVICES.getUserByEmail
   const user = await getUserByUsernameOrEmail(username ?? email)
 
-  if (!user) throw new ForbiddenError("No user found for that username or email.") // Should probably clear any existing auth here
+  if (!user) throw new LoginError("No user found for that username or email.") // Should probably clear any existing auth here
 
   const passwordHash = await SERVICES.getUserPasswordHash(user.id)
 
-  if (!passwordHash) throw new PasswordError("No password hash found for that username or email.")
+  if (!passwordHash) throw new LoginError("No password hash found for that username or email.")
 
-  if (!(await validateHash(password, passwordHash))) throw new PasswordError("Incorrect password.")
+  if (!(await validateHash(password, passwordHash))) throw new LoginError("Incorrect password.")
 
   const refreshTokenId = await SERVICES.createToken({
     userId: user.id,

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -155,6 +155,16 @@ class RateLimitError extends Error {
   }
 }
 
+class LoginError extends Error {
+  public statusCode: ClientErrorCodes
+  constructor(message = "Error logging in.") {
+    super(message)
+    this.name = "LoginError"
+    this.statusCode = HTTP_CLIENT_ERROR.UNAUTHORIZED
+    Object.setPrototypeOf(this, RateLimitError.prototype)
+  }
+}
+
 export {
   BadRequestError,
   ConflictError,
@@ -162,6 +172,7 @@ export {
   EmailError,
   ForbiddenError,
   InternalServerError,
+  LoginError,
   NotAcceptableError,
   NotFoundError,
   NotImplementedError,

--- a/src/middleware/util/errorHandler.ts
+++ b/src/middleware/util/errorHandler.ts
@@ -17,6 +17,7 @@ import {
   RateLimitError,
   TokenError,
   ValidationError,
+  LoginError,
 } from "../../errors"
 
 const errorHandler = (err: Error, _req: Request, res: Response, next: NextFunction) => {
@@ -52,7 +53,11 @@ const errorHandler = (err: Error, _req: Request, res: Response, next: NextFuncti
     return res.status(HTTP_SERVER_ERROR.NOT_IMPLEMENTED).json({ message: "Feature not implemented." })
   }
   if (err instanceof PasswordError) {
-    return res.status(HTTP_CLIENT_ERROR.BAD_REQUEST).json({ message: "Password error." })
+    return res.status(HTTP_CLIENT_ERROR.FORBIDDEN).json({ message: "Access denied." })
+  }
+  // Don't disclose any user/pw information about the error to the client.
+  if (err instanceof LoginError) {
+    return res.status(HTTP_CLIENT_ERROR.FORBIDDEN).json({ message: "Access denied." })
   }
   if (err instanceof PasswordStrengthError) {
     return res.status(HTTP_CLIENT_ERROR.BAD_REQUEST).json({ message: "Password strength insufficient." })

--- a/src/routes/auth/deleteExpiredTokens.ts
+++ b/src/routes/auth/deleteExpiredTokens.ts
@@ -2,13 +2,13 @@ import { Router } from "express"
 import CONTROLLERS from "../../controllers"
 import RBAC from "../../middleware/auth/rbac"
 import { authenticateToken } from "../../middleware/auth/jsonWebTokens"
-import { rateLimitOncePerTenMins } from "../../middleware/util/rateLimiter"
+import { rateLimitTenPerTenMins } from "../../middleware/util/rateLimiter"
 
 const router = Router()
 
 router.delete(
   "/clear-tokens",
-  rateLimitOncePerTenMins,
+  rateLimitTenPerTenMins,
   authenticateToken,
   RBAC.checkCanClearExpiredTokens,
   CONTROLLERS.AUTH.deleteExpiredTokens


### PR DESCRIPTION
Don't tell the client if it's the username or password that's missing