### PR TITLE
fix(db): remove broken migrate/generate scripts in favor of push workflow

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -10,9 +10,9 @@ run_command() {
   echo "$1 done ✅"
 }
 
-# Bump the patch version in package.json
+# Bump the patch version in package.json (also updates package-lock.json)
 npm version patch --no-git-tag-version
-git add package.json
+git add package.json package-lock.json
 
 # Run type coverage check
 npx type-coverage --json-output > .github/type-coverage.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,8 +25,7 @@ npm run typecoverage # Check type coverage (must be ≥90%)
 ### Database Management
 ```bash
 npm run dockerup    # Start PostgreSQL container
-npm run push        # Push schema to database (development)
-npm run migrate     # Run production migrations
+npm run push        # Push schema to database (Drizzle's push workflow)
 npm run studio      # Open Drizzle Studio GUI
 npm run seed        # Seed test users
 npm run seed:owner  # Create initial admin user
@@ -185,9 +184,8 @@ Consistent response structure:
 
 ### Modifying Database Schema
 1. Update schema in `/src/db/schema/`
-2. Run `npm run generate` to create migration
-3. Run `npm run push` (dev) or `npm run migrate` (prod)
-4. Update related services and types
+2. Run `npm run push` to apply the schema to your database
+3. Update related services and types
 
 ## Important Notes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "residents",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "residents",
-      "version": "0.3.11",
+      "version": "0.3.12",
       "license": "MIT",
       "dependencies": {
         "@paralleldrive/cuid2": "^3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "residents",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "residents",
-      "version": "0.3.12",
+      "version": "0.3.13",
       "license": "MIT",
       "dependencies": {
         "@paralleldrive/cuid2": "^3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "residents",
-  "version": "0.3.13",
+  "version": "0.3.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "residents",
-      "version": "0.3.13",
+      "version": "0.3.14",
       "license": "MIT",
       "dependencies": {
         "@paralleldrive/cuid2": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "residents",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "author": "Conor Luddy <conorluddy@gmail.com>",
   "license": "MIT",
   "description": "Residents is a Node.js Express back-end foundation designed for bootstrapping new projects quickly and efficiently. Its main goal is to set up a robust infrastructure for user management, because users are the core of any application. These users are your Residents. It leverages a robust stack including Postgres, Drizzle ORM, JWT, PassportJS, Docker and Swagger to streamline development and deployment processes.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "residents",
-  "version": "0.3.13",
+  "version": "0.3.14",
   "author": "Conor Luddy <conorluddy@gmail.com>",
   "license": "MIT",
   "description": "Residents is a Node.js Express back-end foundation designed for bootstrapping new projects quickly and efficiently. Its main goal is to set up a robust infrastructure for user management, because users are the core of any application. These users are your Residents. It leverages a robust stack including Postgres, Drizzle ORM, JWT, PassportJS, Docker and Swagger to streamline development and deployment processes.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "residents",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "author": "Conor Luddy <conorluddy@gmail.com>",
   "license": "MIT",
   "description": "Residents is a Node.js Express back-end foundation designed for bootstrapping new projects quickly and efficiently. Its main goal is to set up a robust infrastructure for user management, because users are the core of any application. These users are your Residents. It leverages a robust stack including Postgres, Drizzle ORM, JWT, PassportJS, Docker and Swagger to streamline development and deployment processes.",
@@ -18,10 +18,8 @@
     "build": "tsc",
     "dev": "ts-node-dev --respawn --transpile-only src/server.ts",
     "dockerup": "docker-compose up -d",
-    "generate": "drizzle-kit generate",
     "introspect": "drizzle-kit introspect",
     "lint": "eslint .",
-    "migrate": "drizzle-kit migrate",
     "prepare": "husky",
     "prettier": "prettier --write .",
     "push": "drizzle-kit push",

--- a/tests/integration/ownerUserFlow.test.ts
+++ b/tests/integration/ownerUserFlow.test.ts
@@ -4,6 +4,8 @@ import { postgresDatabaseClient } from '../../src/db'
 import seedUserZero from '../../src/db/utils/seedUserZero'
 import { seedUsers } from '../../src/db/utils/seedUsers'
 import { HTTP_SUCCESS } from '../../src/constants/http'
+import { ROLES } from '../../src/constants/database'
+import { SafeUser } from '../../src/db/types'
 import config from '../../src/config'
 
 /**
@@ -86,7 +88,13 @@ describe('Integration: Owner flow from seeded default owner', () => {
     const jwt = loginResponse.body.token
 
     const usersResponse = await request(app).get('/users').set('Authorization', `Bearer ${jwt}`)
-    const userIdToDelete = usersResponse.body.users[3].id
+    // GET /users also returns the seeded owner (Resident Zero). The owner can't
+    // self-delete (CANT_SELF_DELETE), so a fixed index occasionally lands on the
+    // owner and the request 403s. The owner has CAN_DELETE_ANY_USER, so pick any
+    // non-owner user, which is always safely deletable.
+    const userToDelete = usersResponse.body.users.find((u: SafeUser) => u.role !== ROLES.OWNER)
+    expect(userToDelete).toBeDefined()
+    const userIdToDelete = userToDelete.id
 
     const deleteResponse = await request(app).delete(`/users/${userIdToDelete}`).set('Authorization', `Bearer ${jwt}`)
 


### PR DESCRIPTION
## Summary

Two related fixes:
1. **Fixes the broken `npm run migrate`** (#498) by removing it in favor of the `push` workflow the project already standardizes on.
2. **Fixes the husky pre-commit hook** so the version bump stays in sync between `package.json` and `package-lock.json` — the root cause of the mismatch fixed in #496.

## The `migrate` bug

`npm run migrate` (`drizzle-kit migrate`) was broken in **two** ways, both reproduced against a real Postgres 16 instance:

1. **Fresh clone → no migrations to apply.** The migration output dir (`/drizzle`) is gitignored (`.gitignore:42`), so generated migration files are never committed. On a fresh clone, `drizzle-kit migrate` finds no migrations, exits non-zero, and creates **zero tables**.
2. **Existing schema → enum collision.** Run against a schema that already exists (e.g. after `npm run push`, which the README and CI use), it fails with:
   ```
   ERROR: type "tokenType" already exists
   ```
   because the generated migration's first statements are `CREATE TYPE ... AS ENUM(...)`. This is the "throws on an enum label and leaves the schema partial" failure noted in #496.

In both cases `drizzle-kit`'s spinner swallows the error, so it just looks like a silent hang.

### Fix
The project **intentionally** uses Drizzle's `push` workflow — it's what the README (`Initialising the Database`) and CI both use. The leftover `migrate`/`generate` scripts didn't fit that workflow and only served to trap contributors.

- Remove the `migrate` and `generate` scripts from `package.json`.
- Update `AGENTS.md` to document `push` as the single schema workflow.
- `push`, `introspect`, and `studio` are unaffected.

## The husky version-sync bug

The pre-commit hook runs `npm version patch`, which updates **both** `package.json` and `package-lock.json`, but only ran `git add package.json`. That left the lockfile version one patch behind on every commit — the root cause of the version mismatch fixed in #496 (and it nearly re-bit this very PR).

### Fix
- `git add package.json package-lock.json` so both stay in sync.
- Verified end-to-end: the hook fix's own commit correctly bumped and staged both files together (consistent `0.3.13`).

## Verification

- Reproduced both `migrate` failure modes against local Postgres 16.
- Confirmed `npm run push` cleanly creates the full schema (the documented path).
- `eslint .` clean (runs via the pre-commit hook).
- Version consistency confirmed across `package.json` / `package-lock.json`.

Closes #498