### PR TITLE
fix(ci): disable ECR deployment and unbreak the Docker build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,9 @@ jobs:
 
   deploy-to-ecr:
     needs: build-test-and-coverage
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    # Disabled — we are not deploying to ECR. To re-enable, restore:
+    #   if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: false
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,10 @@ WORKDIR /usr/src/app
 # Copy package.json and package-lock.json
 COPY package*.json ./
 
-# Install dependencies including TypeScript
-RUN npm install
+# Install dependencies including TypeScript.
+# --legacy-peer-deps matches ci.yml: @babel/core@8 is ahead of the ^7 peer range
+# that ts-jest's babel plugins still declare.
+RUN npm ci --legacy-peer-deps
 
 # Copy TypeScript configuration and source files
 COPY tsconfig.json ./

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "residents",
-  "version": "0.3.14",
+  "version": "0.3.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "residents",
-      "version": "0.3.14",
+      "version": "0.3.15",
       "license": "MIT",
       "dependencies": {
         "@paralleldrive/cuid2": "^3.0.0",
@@ -60,7 +60,6 @@
         "globals": "^17.0.0",
         "husky": "^9.1.7",
         "jest": "^30.2.0",
-        "openapi-typescript": "^7.13.0",
         "prettier": "^3.9.4",
         "superagent": "^10.2.3",
         "supertest": "^7.1.4",
@@ -4508,122 +4507,6 @@
         "url": "https://opencollective.com/pkgr"
       }
     },
-    "node_modules/@redocly/ajv": {
-      "version": "8.11.2",
-      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.11.2.tgz",
-      "integrity": "sha512-io1JpnwtIcvojV7QKDUSIuMN/ikdOUd1ReEnUnMKGfDVridQZ31J0MmIuqwuRjWDZfmvr+Q0MqCcfHM2gTivOg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js-replace": "^1.0.1"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/@redocly/config": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.22.0.tgz",
-      "integrity": "sha512-gAy93Ddo01Z3bHuVdPWfCwzgfaYgMdaZPcfL7JZ7hWJoK9V0lXDbigTWkhiPFAaLWzbOJ+kbUQG1+XwIm0KRGQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@redocly/openapi-core": {
-      "version": "1.34.16",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.34.16.tgz",
-      "integrity": "sha512-zIgmQTT2TV/U/SJ3N4jlIw36erH6X8ga1UNIoyrlbr0yLEbsiII/16LZ0kMxWu2A8pw0xd56rwTz5sMudy2OAw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@redocly/ajv": "8.11.2",
-        "@redocly/config": "0.22.0",
-        "colorette": "1.4.0",
-        "https-proxy-agent": "7.0.6",
-        "js-levenshtein": "1.1.6",
-        "js-yaml": "4.2.0",
-        "minimatch": "5.1.9",
-        "pluralize": "8.0.0",
-        "yaml-ast-parser": "0.0.43"
-      },
-      "engines": {
-        "node": ">=18.17.0",
-        "npm": ">=9.5.0"
-      }
-    },
-    "node_modules/@redocly/openapi-core/node_modules/agent-base": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/@redocly/openapi-core/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@redocly/openapi-core/node_modules/https-proxy-agent": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/@redocly/openapi-core/node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/@redocly/openapi-core/node_modules/minimatch": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@scarf/scarf": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
@@ -6417,16 +6300,6 @@
         }
       }
     },
-    "node_modules/ansi-colors": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
-      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -7184,13 +7057,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/change-case": {
-      "version": "5.4.4",
-      "resolved": "https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz",
-      "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/char-regex": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
@@ -7432,13 +7298,6 @@
       "engines": {
         "node": ">=12.20"
       }
-    },
-    "node_modules/colorette": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
-      "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -9487,19 +9346,6 @@
         "node": ">=0.8.19"
       }
     },
-    "node_modules/index-to-position": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-1.2.0.tgz",
-      "integrity": "sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -10871,16 +10717,6 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
-    "node_modules/js-levenshtein": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
-      "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -11603,71 +11439,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/openapi-typescript": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/openapi-typescript/-/openapi-typescript-7.13.0.tgz",
-      "integrity": "sha512-EFP392gcqXS7ntPvbhBzbF8TyBA+baIYEm791Hy5YkjDYKTnk/Tn5OQeKm5BIZvJihpp8Zzr4hzx0Irde1LNGQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@redocly/openapi-core": "^1.34.6",
-        "ansi-colors": "^4.1.3",
-        "change-case": "^5.4.4",
-        "parse-json": "^8.3.0",
-        "supports-color": "^10.2.2",
-        "yargs-parser": "^21.1.1"
-      },
-      "bin": {
-        "openapi-typescript": "bin/cli.js"
-      },
-      "peerDependencies": {
-        "typescript": "^5.x"
-      }
-    },
-    "node_modules/openapi-typescript/node_modules/parse-json": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
-      "integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.26.2",
-        "index-to-position": "^1.1.0",
-        "type-fest": "^4.39.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/openapi-typescript/node_modules/supports-color": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
-      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
-    "node_modules/openapi-typescript/node_modules/type-fest": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
-      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -12051,16 +11822,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/pluralize": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
-      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/postgres-array": {
@@ -14513,13 +14274,6 @@
         "punycode": "^2.1.0"
       }
     },
-    "node_modules/uri-js-replace": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/uri-js-replace/-/uri-js-replace-1.0.1.tgz",
-      "integrity": "sha512-W+C9NWNLFOoBI2QWDp4UT9pv65r2w5Cx+3sTYFvtMdDBxkKt1syCqsUdSFAChbEe1uK5TfS04wt/nGwmaeIQ0g==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -14811,13 +14565,6 @@
       "engines": {
         "node": ">= 6"
       }
-    },
-    "node_modules/yaml-ast-parser": {
-      "version": "0.0.43",
-      "resolved": "https://registry.npmjs.org/yaml-ast-parser/-/yaml-ast-parser-0.0.43.tgz",
-      "integrity": "sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A==",
-      "dev": true,
-      "license": "Apache-2.0"
     },
     "node_modules/yargs": {
       "version": "17.7.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "residents",
-  "version": "0.3.15",
+  "version": "0.3.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "residents",
-      "version": "0.3.15",
+      "version": "0.3.16",
       "license": "MIT",
       "dependencies": {
         "@paralleldrive/cuid2": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "residents",
-  "version": "0.3.15",
+  "version": "0.3.16",
   "author": "Conor Luddy <conorluddy@gmail.com>",
   "license": "MIT",
   "description": "Residents is a Node.js Express back-end foundation designed for bootstrapping new projects quickly and efficiently. Its main goal is to set up a robust infrastructure for user management, because users are the core of any application. These users are your Residents. It leverages a robust stack including Postgres, Drizzle ORM, JWT, PassportJS, Docker and Swagger to streamline development and deployment processes.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "residents",
-  "version": "0.3.14",
+  "version": "0.3.15",
   "author": "Conor Luddy <conorluddy@gmail.com>",
   "license": "MIT",
   "description": "Residents is a Node.js Express back-end foundation designed for bootstrapping new projects quickly and efficiently. Its main goal is to set up a robust infrastructure for user management, because users are the core of any application. These users are your Residents. It leverages a robust stack including Postgres, Drizzle ORM, JWT, PassportJS, Docker and Swagger to streamline development and deployment processes.",
@@ -93,7 +93,6 @@
     "globals": "^17.0.0",
     "husky": "^9.1.7",
     "jest": "^30.2.0",
-    "openapi-typescript": "^7.13.0",
     "prettier": "^3.9.4",
     "superagent": "^10.2.3",
     "supertest": "^7.1.4",


### PR DESCRIPTION
## Context

CI on `main` has had a red `deploy-to-ecr` job on every run since at least 22 June. The `build-test-and-coverage` jobs were passing, so the breakage was easy to miss.

We're not actually using the ECR deployment, so the primary fix here is to turn it off. The Dockerfile bug it exposed is fixed too, since the image still needs to build for local use.

## Changes

**1. Disable `deploy-to-ecr`** — gated off with `if: false` rather than deleted, so the steps stay in place for whenever it's wanted again. This is what was reddening main.

**2. Fix the Dockerfile install** — the workflow and the Dockerfile disagreed:

- `.github/workflows/ci.yml:37` — `npm install --legacy-peer-deps`
- `Dockerfile:11` — `npm install`

Dependabot has pulled majors ahead of the ecosystem, leaving peer conflicts. The test job tolerated them via `--legacy-peer-deps`; the Docker build didn't, and died with `ERESOLVE`. Two stacked conflicts, not one:

| Conflict | Detail |
|---|---|
| `openapi-typescript@7.13.0` | peers `typescript@^5.x`, repo is on `typescript@^6.0.3` |
| `ts-jest@29.4.11` | peers `@babel/core@^7`, repo is on `@babel/core@8.0.1` |

Now uses `npm ci --legacy-peer-deps`, matching both `ci.yml` and the `publish-to-npm` job (`ci.yml:124`), and building reproducibly from the committed lockfile.

**3. Drop `openapi-typescript`** — nothing imports it and no script invokes it; the only reference in the repo was its own dependency entry. (The `openapi:` key in `src/swagger/index.ts:11` is swagger-jsdoc config, unrelated.) This clears the first conflict but not the second, so `--legacy-peer-deps` is still required. No upstream fix exists — `7.13.0` is the latest published version and still pins `typescript@^5.x`.

## Verification

- `docker build` passes locally — fresh `npm ci --legacy-peer-deps` install and `tsc` build both succeed. This is the exact step that was failing.
- `npm run build` and `npm run typecoverage` pass (98.55%).
- DB-free unit tests pass (4 suites, 29 tests) — confirms the lockfile regen didn't shift ts-jest/babel resolution.
- Workflow YAML validated; `publish-to-npm` depends on `build-test-and-coverage`, not `deploy-to-ecr`, so the release path is unaffected.

Note that `deploy-to-ecr` never ran on PRs anyway (it was gated on push-to-main), which is why this went unnoticed for a month — the Dockerfile was only ever built after merge. The full test suite is left to CI; the Postgres port `drizzle.config.ts:12` hardcodes was occupied locally by an unrelated project's container.

## Not in scope

- **Version pinning strategy** — whether to hold `typescript` at `^5` and `@babel/core` at `^7` until the ecosystem catches up, or keep using `--legacy-peer-deps`, is worth deciding deliberately.
- **`codecov/codecov-action@v4.0.1`** — the `24.x` job in one recent run flaked with `write EPIPE` inside the action's bundled gpg module. One-off, but the pin is old and the runner now warns Node 20 is deprecated.